### PR TITLE
Make optional dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
   "homepage": "https://github.com/alykoshin/winston-winlog3",
   "dependencies": {
     "circular-json": "^0.3.1",
-    "node-windows2": "^0.0.3",
     "winston": "^2.3.1"
+  },
+  "optionalDependencies": {
+    "node-windows2": "^0.0.3"
   }
 }


### PR DESCRIPTION
I was trying to use this module with yarn, but it fails to install this module on OS X because of the hard dependency on node-windows2.  This uses the optional dependency field instead which seems the correct way to solve this given https://docs.npmjs.com/files/package.json#optionaldependencies